### PR TITLE
Fix usage message

### DIFF
--- a/totp.rb
+++ b/totp.rb
@@ -6,7 +6,7 @@ require 'rotp'
 require 'open3'
 
 if ARGV.size != 1
-  puts "Usage: otp SERVICE"
+  warn "Usage: #{File.basename(__FILE__)} SERVICE"
   exit 1
 end
 


### PR DESCRIPTION
Call `warn` to send to stderr, and replace the incorrect `otp` with a call to find the actual script name through `__FILE__`