### PR TITLE
Make clipboard selection same as that of pass

### DIFF
--- a/totp.rb
+++ b/totp.rb
@@ -31,7 +31,8 @@ class GenerateCmd < CmdParse::Command
     token = totp.now
     puts token
 
-    Open3.popen3 "xclip" do | stdin, stdout, stderr, wait |
+    x_selection = ENV["PASSWORD_STORE_X_SELECTION"] || 'clipboard'
+    Open3.popen3("xclip -selection #{x_selection}") do | stdin, stdout, stderr, wait |
       stdin.puts token.chomp
       stdin.close
     end


### PR DESCRIPTION
As totp-cli depends on pass, it would be sensible for it to select the same clipboard as pass - as users of totp-cli are very likely users of pass.

Use pass's environment variable PASSWORD_STORE_X_SELECTION to set the clipboard selection. If PASSWORD_STORE_X_SELECTION is not set, default to clipboard - which is the default clipboard selection used by pass.