### PR TITLE
Fixed README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Requirements
 
  * `pass <http://www.passwordstore.org/>`_
  * `xclip <http://sourceforge.net/projects/xclip>`_
- * `python <https://www.python.org/>`_
+ * `python >= 3.3 <https://www.python.org/>`_
 
 
 Installation
@@ -68,7 +68,7 @@ Installation
 
 Installation is quite simple:
 
-    $ pip install totp-cli
+    $ pip install totp
 
 There is also an `AUR package`_ available for ArchLinux users.
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python3
 
 from setuptools import setup
+import sys
+
+if sys.version_info < (3, 3):
+    raise RuntimeError(
+        'totp-cli requires python >= 3.3, but this python is %d.%d' %
+        sys.version_info[0:2]
+    )
 
 setup(
     name='totp',


### PR DESCRIPTION
- totp-cli does not work on python 2.x
- pip package name is not `totp-cli` but `totp`