### PR TITLE
Support adding a service through a flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Default X selection can be overridden with the PASSWORD_STORE_X_SELECTION
 environment variable.
 
 Shared keys should be stored in your pass storage under ``2fa/SERVICE/code``,
-for example ``2fa/github/code``. The add command can be used to add this less
+for example ``2fa/github/code``. The ``-a`` flag can be used to add this less
 painfully
 
 .. _pass: http://www.passwordstore.org/
@@ -43,6 +43,20 @@ For example::
 You don't need to run ``totp`` from the command line if you just want to paste
 the code; you can run if from ``dmenu``, or whatever your application launcher
 is.
+
+To add a service::
+
+    totp -a SERVICE
+
+For example::
+
+    $ totp -a github
+    Token length [6]: 6
+    Shared key: KEY
+
+Note that if the service already exists, it will be overwritten without
+warning.
+
 
 About pass entries
 ------------------

--- a/totp/__init__.py
+++ b/totp/__init__.py
@@ -99,22 +99,27 @@ def copy_to_clipboard(text):
         )
 
 
+def generate_token(path):
+    """Generate the TOTP token for the given path"""
+    pass_entry = get_pass_entry(path)
+
+    # Remove the trailing newline or any other custom data users might have
+    # saved:
+    pass_entry = pass_entry.splitlines()
+    secret = pass_entry[0]
+
+    digits = get_length(pass_entry)
+    token = onetimepass.get_totp(secret, as_string=True, token_length=digits)
+
+    print(token.decode())
+    copy_to_clipboard(token)
+
+
 def run():
     if sys.argv[1] == '-a':
         add_pass_entry(sys.argv[2])
     else:
-        pass_entry = get_pass_entry(sys.argv[1])
-
-        # Remove the trailing newline or any other custom data users might have
-        # saved:
-        pass_entry = pass_entry.splitlines()
-        secret = pass_entry[0]
-
-        digits = get_length(pass_entry)
-        token = onetimepass.get_totp(secret, as_string=True, token_length=digits)
-
-        print(token.decode())
-        copy_to_clipboard(token)
+        generate_token(sys.argv[1])
 
 
 if __name__ == '__main__':

--- a/totp/__init__.py
+++ b/totp/__init__.py
@@ -32,7 +32,7 @@ def add_pass_entry(path):
 
     shared_key = getpass.getpass('Shared key: ')
 
-    pass_entry = "digits: {}\n{}".format(token_length, shared_key)
+    pass_entry = "{}\ndigits: {}\n".format(shared_key, token_length)
 
     p = subprocess.Popen(
         ['pass', 'insert', '-m', code_path],

--- a/totp/__init__.py
+++ b/totp/__init__.py
@@ -35,7 +35,7 @@ def add_pass_entry(path):
     pass_entry = "{}\ndigits: {}\n".format(shared_key, token_length)
 
     p = subprocess.Popen(
-        ['pass', 'insert', '-m', code_path],
+        ['pass', 'insert', '-m', '-f', code_path],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE


### PR DESCRIPTION
Add the -a flag to add a service. The program will prompt for a token length (defaulting to 6 if none is given) and the shared key. This will overwrite an existing service with the same name without warning.