### PR TITLE
Clock offset

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,8 +41,19 @@ For example::
     621787
 
 You don't need to run ``totp`` from the command line if you just want to paste
-the code; you can run if from ``dmenu``, or whatever your application launcher
+the code; you can run it from ``dmenu``, or whatever your application launcher
 is.
+
+To offset the clock by a number of seconds::
+
+    totp -s SECONDS SERVICE
+
+For example::
+
+    $ totp -s +60 github
+    735092
+    $ totp -s -90 github
+    909651
 
 To add a service::
 

--- a/totp/__init__.py
+++ b/totp/__init__.py
@@ -100,8 +100,11 @@ def copy_to_clipboard(text):
         )
 
 
-def generate_token(path):
-    """Generate the TOTP token for the given path"""
+def generate_token(path, seconds=0):
+    """Generate the TOTP token for the given path and the given time offset"""
+    import time
+    clock = time.time() + float(seconds)
+
     pass_entry = get_pass_entry(path)
 
     # Remove the trailing newline or any other custom data users might have
@@ -110,7 +113,8 @@ def generate_token(path):
     secret = pass_entry[0]
 
     digits = get_length(pass_entry)
-    token = onetimepass.get_totp(secret, as_string=True, token_length=digits)
+    token = onetimepass.get_totp(secret, as_string=True, token_length=digits,
+                                 clock=clock)
 
     print(token.decode())
     copy_to_clipboard(token)
@@ -119,6 +123,8 @@ def generate_token(path):
 def run():
     if sys.argv[1] == '-a':
         add_pass_entry(sys.argv[2])
+    elif sys.argv[1] == '-s':
+        generate_token(sys.argv[3], seconds=sys.argv[2])
     else:
         generate_token(sys.argv[1])
 


### PR DESCRIPTION
I use this sometimes from a VM with a wonky clock. To get the right code it's possible to do something like:

`faketime -f -90s totp-cli github`

This PR enables this without an external tool. And it assumes you only care about offset in seconds. To do the above:

`totp-cli -s -90 github`

It doesn't impose `argparse` or anything, just an `elif`, so the order of args is strict.
P.S., totp-cli groans ungracefully if passed no args.