### PR TITLE
Proposal: Cleaner CLI + Support for adding otpauth:// URIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build
 dist
 .eggs
+__pycache__/

--- a/README.rst
+++ b/README.rst
@@ -23,8 +23,8 @@ Default X selection can be overridden with the PASSWORD_STORE_X_SELECTION
 environment variable.
 
 Shared keys should be stored in your pass storage under ``2fa/SERVICE/code``,
-for example ``2fa/github/code``. The ``add`` subcommand can be used to add this
-less painfully.
+for example ``2fa/github/code``. The ``-a`` flag (or alternatively the ``add``
+subcommand) can be used to add this less painfully.
 
 .. _pass: http://www.passwordstore.org/
 
@@ -57,11 +57,13 @@ For example::
 
 To add a service::
 
+    totp -a SERVICE
+    # OR
     totp add SERVICE
 
 For example::
 
-    $ totp add github
+    $ totp -a github
     Token length [6]: 6
     Shared key: KEY
 

--- a/README.rst
+++ b/README.rst
@@ -23,8 +23,8 @@ Default X selection can be overridden with the PASSWORD_STORE_X_SELECTION
 environment variable.
 
 Shared keys should be stored in your pass storage under ``2fa/SERVICE/code``,
-for example ``2fa/github/code``. The ``-a`` flag can be used to add this less
-painfully
+for example ``2fa/github/code``. The ``add`` subcommand can be used to add this
+less painfully.
 
 .. _pass: http://www.passwordstore.org/
 
@@ -57,11 +57,11 @@ For example::
 
 To add a service::
 
-    totp -a SERVICE
+    totp add SERVICE
 
 For example::
 
-    $ totp -a github
+    $ totp add github
     Token length [6]: 6
     Shared key: KEY
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=['totp'],
     entry_points={
         'console_scripts': [
-            'totp = totp:run',
+            'totp = totp.cli:run',
         ]
     },
     install_requires=[

--- a/totp/__init__.py
+++ b/totp/__init__.py
@@ -118,16 +118,3 @@ def generate_token(path, seconds=0):
 
     print(token.decode())
     copy_to_clipboard(token)
-
-
-def run():
-    if sys.argv[1] == '-a':
-        add_pass_entry(sys.argv[2])
-    elif sys.argv[1] == '-s':
-        generate_token(sys.argv[3], seconds=sys.argv[2])
-    else:
-        generate_token(sys.argv[1])
-
-
-if __name__ == '__main__':
-    run()

--- a/totp/__init__.py
+++ b/totp/__init__.py
@@ -128,6 +128,16 @@ def copy_to_clipboard(text):
         )
 
 
+def normalize_secret(secret):
+    s = secret.replace(' ', '')
+
+    if len(s) % 8 != 0:
+        missing = 8 - (len(s) % 8)
+        s += '=' * missing
+
+    return s
+
+
 def generate_token(path, seconds=0):
     """Generate the TOTP token for the given path and the given time offset"""
     import time
@@ -138,7 +148,7 @@ def generate_token(path, seconds=0):
     # Remove the trailing newline or any other custom data users might have
     # saved:
     pass_entry = pass_entry.splitlines()
-    secret = pass_entry[0]
+    secret = normalize_secret(pass_entry[0])
 
     digits = get_length(pass_entry)
     token = onetimepass.get_totp(secret, as_string=True, token_length=digits,

--- a/totp/__init__.py
+++ b/totp/__init__.py
@@ -132,8 +132,8 @@ def normalize_secret(secret):
     s = secret.replace(' ', '')
 
     if len(s) % 8 != 0:
-        missing = 8 - (len(s) % 8)
-        s += '=' * missing
+        num_needed_padding_chars = 8 - (len(s) % 8)
+        s += '=' * num_needed_padding_chars
 
     return s
 

--- a/totp/__init__.py
+++ b/totp/__init__.py
@@ -18,25 +18,15 @@ DIGITS_DEFAULT = 6
 class BackendError(Exception):
     backend_name = '<none>'
 
-    def __init__(self, msg):
-        self.msg = msg
-
 class PassBackendError(BackendError):
     backend_name = 'pass'
 
+    def __init__(self, err):
+        if isinstance(err, bytes):
+            err = err.decode('utf-8', 'replace')
+        super().__init__(err.rstrip('\n'))
 
-def _read_backend_error(err):
-    if isinstance(err, bytes):
-        try:
-            err = err.decode('utf-8')
-        except UnicodeDecodeError:
-            return bytestr
-    return err.rstrip('\n')
-
-
-class ValidationError(Exception):
-    def __init__(self, msg):
-        self.msg = msg
+class ValidationError(Exception): pass
 
 def validate(*args):
     for (validator, error_message) in args:
@@ -77,7 +67,7 @@ def add_pass_entry(path, token_length, shared_key):
     )
 
     if len(err) > 0:
-        raise PassBackendError(_read_backend_error(err))
+        raise PassBackendError(err)
 
 
 def get_pass_entry(path):
@@ -94,7 +84,7 @@ def get_pass_entry(path):
     pass_output, err = p.communicate()
 
     if len(err) > 0:
-        raise PassBackendError(_read_backend_error(err))
+        raise PassBackendError(err)
 
     return pass_output.decode()
 

--- a/totp/cli.py
+++ b/totp/cli.py
@@ -1,34 +1,20 @@
 import argparse
 import sys
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict, defaultdict, namedtuple
 from functools import reduce
 
 import totp
 
-# Suggestion from https://stackoverflow.com/a/26379693/302264, refactored
-def _ensure_default_subparser(default, parser, args):
-    """Ensure a subcommand is present in `args`; if no valid subcommand is
-    found, `default` is inserted as the first element of `args`.
-    default: the name of the subparser to call by default
-    args: the argument list that is to be handed to parse_args()
-    """
-    def add_default_subcommand(args, default):
-        # insert default in first position, this implies no
-        # global options without a sub_parsers specified
-        args.insert(0, default)
+_subcommands = {}
 
-    def has_explicit_subcommand(args, parser):
-        return any(sp_name in args
-            for action in parser._subparsers._actions
-                   if isinstance(action, argparse._SubParsersAction)
-            for sp_name in action._name_parser_map.keys())
+_argument = namedtuple('argument', ['args', 'kwargs'])
+def argument(*args, **kwargs):
+    return _argument(args, kwargs)
 
-    for arg in args:
-        if arg in ['-h', '--help']:  # global help if no subparser
-            return
-
-    if not has_explicit_subcommand(args, parser):
-        add_default_subcommand(args, default=default)
+def subcommand(name, *args, **kwargs):
+    def decorator(func):
+        _subcommands[name] = (args, kwargs, func)
+    return decorator
 
 def _parse_args(args):
     parser = argparse.ArgumentParser(
@@ -37,43 +23,44 @@ def _parse_args(args):
 
     subparsers = parser.add_subparsers(dest='command')
 
-    # ---
-    add_parser = subparsers.add_parser('add',
-        description='Add a new TOTP entry to the database.',
-        help='add a new TOTP entry to the database')
+    for name, (_args, kwargs, func) in _subcommands.items():
+        _parser = subparsers.add_parser(name, **kwargs)
+        _parser.set_defaults(func=func)
+        for arg in _args:
+            _parser.add_argument(*arg.args, **arg.kwargs)
 
-    add_parser.add_argument('identifier',
-        help='the identifier under the \'2fa\' folder where the key should be saved')
+    def add_default_subcommand_if_omitted(args, default):
+        if not any(arg in ('-h', '--help') or arg in subparsers.choices for arg in args):
+            args.insert(0, default)
 
-    # ---
-    show_parser = subparsers.add_parser('show',
-        description='Show the current TOTP token for a registered entry.',
-        help='(default action) show the current TOTP token for a registered entry')
+    add_default_subcommand_if_omitted(args, 'show')
 
-    show_parser.add_argument('-s', dest='offset_seconds', metavar='SECONDS', default=0,
-        help='offset the clock by the given number of seconds')
-
-    show_parser.add_argument('identifier',
-        help='the identifier by which the key can be found under the \'2fa\' folder')
-
-    # ---
-    _ensure_default_subparser('show', parser, args)
     return parser.parse_args(args)
 
 def run():
     args = _parse_args(sys.argv[1:])
     try:
-        _run(args)
+        args.func(args)
     except KeyboardInterrupt:
         print()
 
-def _run(args):
-    if args.command == 'add':
-        totp.add_pass_entry(args.identifier)
-    elif args.command == 'show':
-        totp.generate_token(args.identifier, seconds=args.offset_seconds)
-    else:
-        assert False, 'unexpected command: %r' % args.command
+@subcommand('add',
+    argument('identifier',
+        help='the identifier under the \'2fa\' folder where the key should be saved'),
+    description='Add a new TOTP entry to the database.',
+    help='add a new TOTP entry to the database')
+def _cmd_add(args):
+    totp.add_pass_entry(args.identifier)
+
+@subcommand('show',
+    argument('-s', dest='offset_seconds', metavar='SECONDS', default=0,
+        help='offset the clock by the given number of seconds'),
+    argument('identifier',
+        help='the identifier by which the key can be found under the \'2fa\' folder'),
+    description='Show the current TOTP token for a registered entry.',
+    help='(default action) show the current TOTP token for a registered entry')
+def _cmd_show(args):
+    totp.generate_token(args.identifier, seconds=args.offset_seconds)
 
 if __name__ == '__main__':
     run()

--- a/totp/cli.py
+++ b/totp/cli.py
@@ -73,11 +73,22 @@ def _cmd_add(args):
     else:
         add_interactive(args.identifier)
 
+def input_shared_key():
+    while True:
+        try:
+            shared_key = totp.normalize_secret(getpass.getpass('Shared key: '))
+            b32decode(shared_key.upper())
+            if shared_key == "":
+                raise ValueError('The key entered was empty')
+            return shared_key
+        except ValueError as err:
+            print(*err.args)
+
 def add_interactive(path):
     token_length = input('Token length [%d]: ' % totp.DIGITS_DEFAULT)
     token_length = int(token_length) if token_length else totp.DIGITS_DEFAULT
 
-    shared_key = getpass.getpass('Shared key: ')
+    shared_key = input_shared_key()
 
     totp.add_pass_entry(path, token_length, shared_key)
 

--- a/totp/cli.py
+++ b/totp/cli.py
@@ -22,6 +22,7 @@ def _parse_args(args):
     )
 
     subparsers = parser.add_subparsers(dest='command')
+    aliases = {}
 
     for name, (_args, kwargs, func) in _subcommands.items():
         _parser = subparsers.add_parser(name, **kwargs)
@@ -29,10 +30,20 @@ def _parse_args(args):
         for arg in _args:
             _parser.add_argument(*arg.args, **arg.kwargs)
 
+        _aliases = kwargs.get('aliases', ())
+        for alias in _aliases:
+            aliases[alias] = name
+
+    def replace_aliases(args, aliases):
+        for i, arg in enumerate(args):
+            if arg in aliases:
+                args[i] = aliases[arg]
+
     def add_default_subcommand_if_omitted(args, default):
         if not any(arg in ('-h', '--help') or arg in subparsers.choices for arg in args):
             args.insert(0, default)
 
+    replace_aliases(args, aliases)
     add_default_subcommand_if_omitted(args, 'show')
 
     return parser.parse_args(args)
@@ -47,6 +58,7 @@ def run():
 @subcommand('add',
     argument('identifier',
         help='the identifier under the \'2fa\' folder where the key should be saved'),
+    aliases=['-a'],
     description='Add a new TOTP entry to the database.',
     help='add a new TOTP entry to the database')
 def _cmd_add(args):

--- a/totp/cli.py
+++ b/totp/cli.py
@@ -62,19 +62,27 @@ def run():
 @subcommand('add',
     argument('identifier',
         help='the identifier under the \'2fa\' folder where the key should be saved'),
+    argument('-u', '--uri',
+        help='an optional otpauth uri to read the entry data from'),
     aliases=['-a'],
     description='Add a new TOTP entry to the database.',
     help='add a new TOTP entry to the database')
 def _cmd_add(args):
-    add_interactive(args.identifier)
+    if args.uri:
+        add_uri(args.identifier, args.uri)
+    else:
+        add_interactive(args.identifier)
 
 def add_interactive(path):
-    token_length = input('Token length [6]: ')
-    token_length = int(token_length) if token_length else 6
+    token_length = input('Token length [%d]: ' % totp.DIGITS_DEFAULT)
+    token_length = int(token_length) if token_length else totp.DIGITS_DEFAULT
 
     shared_key = getpass.getpass('Shared key: ')
 
     totp.add_pass_entry(path, token_length, shared_key)
+
+def add_uri(path, uri):
+    totp.add_pass_entry_from_uri(path, uri)
 
 @subcommand('show',
     argument('-s', dest='offset_seconds', metavar='SECONDS', default=0,

--- a/totp/cli.py
+++ b/totp/cli.py
@@ -1,0 +1,79 @@
+import argparse
+import sys
+from collections import OrderedDict, defaultdict
+from functools import reduce
+
+import totp
+
+# Suggestion from https://stackoverflow.com/a/26379693/302264, refactored
+def _ensure_default_subparser(default, parser, args):
+    """Ensure a subcommand is present in `args`; if no valid subcommand is
+    found, `default` is inserted as the first element of `args`.
+    default: the name of the subparser to call by default
+    args: the argument list that is to be handed to parse_args()
+    """
+    def add_default_subcommand(args, default):
+        # insert default in first position, this implies no
+        # global options without a sub_parsers specified
+        args.insert(0, default)
+
+    def has_explicit_subcommand(args, parser):
+        return any(sp_name in args
+            for action in parser._subparsers._actions
+                   if isinstance(action, argparse._SubParsersAction)
+            for sp_name in action._name_parser_map.keys())
+
+    for arg in args:
+        if arg in ['-h', '--help']:  # global help if no subparser
+            return
+
+    if not has_explicit_subcommand(args, parser):
+        add_default_subcommand(args, default=default)
+
+def _parse_args(args):
+    parser = argparse.ArgumentParser(
+        description='Print a TOTP token getting the shared key from pass(1).'
+    )
+
+    subparsers = parser.add_subparsers(dest='command')
+
+    # ---
+    add_parser = subparsers.add_parser('add',
+        description='Add a new TOTP entry to the database.',
+        help='add a new TOTP entry to the database')
+
+    add_parser.add_argument('identifier',
+        help='the identifier under the \'2fa\' folder where the key should be saved')
+
+    # ---
+    show_parser = subparsers.add_parser('show',
+        description='Show the current TOTP token for a registered entry.',
+        help='(default action) show the current TOTP token for a registered entry')
+
+    show_parser.add_argument('-s', dest='offset_seconds', metavar='SECONDS', default=0,
+        help='offset the clock by the given number of seconds')
+
+    show_parser.add_argument('identifier',
+        help='the identifier by which the key can be found under the \'2fa\' folder')
+
+    # ---
+    _ensure_default_subparser('show', parser, args)
+    return parser.parse_args(args)
+
+def run():
+    args = _parse_args(sys.argv[1:])
+    try:
+        _run(args)
+    except KeyboardInterrupt:
+        print()
+
+def _run(args):
+    if args.command == 'add':
+        totp.add_pass_entry(args.identifier)
+    elif args.command == 'show':
+        totp.generate_token(args.identifier, seconds=args.offset_seconds)
+    else:
+        assert False, 'unexpected command: %r' % args.command
+
+if __name__ == '__main__':
+    run()

--- a/totp/cli.py
+++ b/totp/cli.py
@@ -59,10 +59,14 @@ def run():
     except KeyboardInterrupt:
         print()
 
-@subcommand('add',
-    argument('identifier',
+@subcommand(
+    'add',
+    argument(
+        'identifier',
         help='the identifier under the \'2fa\' folder where the key should be saved'),
-    argument('-u', '--uri',
+    argument(
+        '-u',
+        '--uri',
         help='an optional otpauth uri to read the entry data from'),
     aliases=['-a'],
     description='Add a new TOTP entry to the database.',
@@ -95,10 +99,16 @@ def add_interactive(path):
 def add_uri(path, uri):
     totp.add_pass_entry_from_uri(path, uri)
 
-@subcommand('show',
-    argument('-s', dest='offset_seconds', metavar='SECONDS', default=0,
+@subcommand(
+    'show',
+    argument(
+        '-s',
+        dest='offset_seconds',
+        metavar='SECONDS',
+        default=0,
         help='offset the clock by the given number of seconds'),
-    argument('identifier',
+    argument(
+        'identifier',
         help='the identifier by which the key can be found under the \'2fa\' folder'),
     description='Show the current TOTP token for a registered entry.',
     help='(default action) show the current TOTP token for a registered entry')

--- a/totp/cli.py
+++ b/totp/cli.py
@@ -54,7 +54,7 @@ def run():
     try:
         args.func(args)
     except totp.BackendError as e:
-        print('%s returned an error:\n%s' % (e.backend_name, e.msg))
+        print('%s returned an error:\n%s' % (e.backend_name, e))
         raise SystemExit(-1)
     except KeyboardInterrupt:
         print()


### PR DESCRIPTION
Hello there! Almost a year ago I found this project but I needed to make some changes for it to work for me. I was going to send them as a PR but then I forgot :roll_eyes:

One of the issues I intended to solve was padding to multiples of 8 bytes. In the meantime this was done in #9 but I kept my implementation because the code seemed clearer and simpler to me.

Another was refactoring the command-line interface, for 1) making the user-facing part more "elegant", using the standard argparse module, and 2) better separation of concerns, less coupling between relevant domain code and UI code.

Finally I also added an option to add secrets via `otpauth://` URIs, as described in https://github.com/google/google-authenticator/wiki/Key-Uri-Format - see below for an example:

```
otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example
```

If you're interested in incorporating part of those changes feel free to ask me for a smaller PR! :-)