### PR TITLE
Add a missing import for b32decode

### DIFF
--- a/totp/cli.py
+++ b/totp/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import getpass
 import sys
+from base64 import b32decode
 from collections import OrderedDict, defaultdict, namedtuple
 from functools import reduce
 


### PR DESCRIPTION
This commit fixes a NameError that was introduced in 132f54ade.