### PR TITLE
Add show-only subcommand in CLI + Fish completion file

### DIFF
--- a/contrib/totp-cli-completion.fish
+++ b/contrib/totp-cli-completion.fish
@@ -1,0 +1,8 @@
+# subcommands
+complete -xc totp -n '__fish_use_subcommand' -a show -d 'Show the current TOTP token for a registered entry'
+complete -xc totp -n '__fish_use_subcommand' -a show-only -d 'Show the current TOTP token for a registered entry - don\'t copy to clipboard'
+complete -xc totp -n '__fish_use_subcommand' -a add -d 'Add a new TOTP entry to the database'
+
+# 2FA codes
+test -z "$PASSWORD_STORE_DIR"; and set PASSWORD_STORE_DIR "$HOME/.password-store"
+complete -xc totp -a '(command ls $PASSWORD_STORE_DIR/2fa)' -d "2FA code"

--- a/contrib/totp-cli-completion.fish
+++ b/contrib/totp-cli-completion.fish
@@ -1,7 +1,8 @@
 # subcommands
 complete -xc totp -n '__fish_use_subcommand' -a show -d 'Show the current TOTP token for a registered entry'
-complete -xc totp -n '__fish_use_subcommand' -a show-only -d 'Show the current TOTP token for a registered entry - don\'t copy to clipboard'
 complete -xc totp -n '__fish_use_subcommand' -a add -d 'Add a new TOTP entry to the database'
+
+complete -xc totp -n '__fish_seen_subcommand_from show' -a '-n --nocopy' -d 'Show TOKEN but don\'t copy to clipboard'
 
 # 2FA codes
 test -z "$PASSWORD_STORE_DIR"; and set PASSWORD_STORE_DIR "$HOME/.password-store"

--- a/totp/__init__.py
+++ b/totp/__init__.py
@@ -128,7 +128,7 @@ def normalize_secret(secret):
     return s
 
 
-def generate_token(path, seconds=0):
+def generate_token(path, seconds=0, to_clipboard=True):
     """Generate the TOTP token for the given path and the given time offset"""
     import time
     clock = time.time() + float(seconds)
@@ -145,7 +145,9 @@ def generate_token(path, seconds=0):
                                  clock=clock)
 
     print(token.decode())
-    copy_to_clipboard(token)
+
+    if to_clipboard:
+        copy_to_clipboard(token)
 
 
 def parse_otpauth_uri(uri):

--- a/totp/cli.py
+++ b/totp/cli.py
@@ -109,28 +109,16 @@ def add_uri(path, uri):
         default=0,
         help='offset the clock by the given number of seconds'),
     argument(
+        '-n', '--nocopy',
+        action="store_true",
+        help='Show the current TOTP token for a registered entry - don\'t copy to clipboard'),
+    argument(
         'identifier',
         help='the identifier by which the key can be found under the \'2fa\' folder'),
     description='Show the current TOTP token for a registered entry.',
     help='(default action) show the current TOTP token for a registered entry')
 def _cmd_show(args):
-    totp.generate_token(args.identifier, seconds=args.offset_seconds)
-
-@subcommand(
-    'show-only',
-    argument(
-        '-S',
-        dest='offset_seconds',
-        metavar='SECONDS',
-        default=0,
-        help='offset the clock by the given number of seconds'),
-    argument(
-        'identifier',
-        help='the identifier by which the key can be found under the \'2fa\' folder'),
-    description='Show the current TOTP token for a registered entry - don\'t copy to clipboard',
-    help='show the current TOTP token for a registered entry - don\'t copy to clipboard')
-def _cmd_show(args):
-    totp.generate_token(args.identifier, seconds=args.offset_seconds, to_clipboard=False)
+    totp.generate_token(args.identifier, seconds=args.offset_seconds, to_clipboard=not args.nocopy)
 
 if __name__ == '__main__':
     run()

--- a/totp/cli.py
+++ b/totp/cli.py
@@ -116,5 +116,21 @@ def add_uri(path, uri):
 def _cmd_show(args):
     totp.generate_token(args.identifier, seconds=args.offset_seconds)
 
+@subcommand(
+    'show-only',
+    argument(
+        '-S',
+        dest='offset_seconds',
+        metavar='SECONDS',
+        default=0,
+        help='offset the clock by the given number of seconds'),
+    argument(
+        'identifier',
+        help='the identifier by which the key can be found under the \'2fa\' folder'),
+    description='Show the current TOTP token for a registered entry - don\'t copy to clipboard',
+    help='show the current TOTP token for a registered entry - don\'t copy to clipboard')
+def _cmd_show(args):
+    totp.generate_token(args.identifier, seconds=args.offset_seconds, to_clipboard=False)
+
 if __name__ == '__main__':
     run()

--- a/totp/cli.py
+++ b/totp/cli.py
@@ -111,7 +111,7 @@ def add_uri(path, uri):
     argument(
         '-n', '--nocopy',
         action="store_true",
-        help='Show the current TOTP token for a registered entry - don\'t copy to clipboard'),
+        help='Do not copy the token, only show it.'),
     argument(
         'identifier',
         help='the identifier by which the key can be found under the \'2fa\' folder'),


### PR DESCRIPTION
Hi there,

Thanks for this excellent tool.
I've used this tool to show 2FA codes using the [Albert](https://albertlauncher.github.io/) launcher.

https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/pass_totp_cli