### PR TITLE
Add undocumented command-line option to the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,12 @@ For example::
 Note that if the service already exists, it will be overwritten without
 warning.
 
+To output without copying to the clipboard:
+
+    $ totp -n SERVICE
+    # OR
+    $ totp --nocopy SERVICE
+
 
 About pass entries
 ------------------


### PR DESCRIPTION
I was trying to figure out a way to disable the clipboard functionality and since I'm on OSX the environment variable did not work for me. After digging through the code I found the -n / --nocopy option. Thought others may find this useful as well.