### PR TITLE
Use returncode to determine backend errors

### DIFF
--- a/totp/__init__.py
+++ b/totp/__init__.py
@@ -66,7 +66,7 @@ def add_pass_entry(path, token_length, shared_key):
         input=bytearray(pass_entry, encoding='utf-8')
     )
 
-    if len(err) > 0:
+    if p.returncode != 0:
         raise PassBackendError(err)
 
 
@@ -83,7 +83,7 @@ def get_pass_entry(path):
 
     pass_output, err = p.communicate()
 
-    if len(err) > 0:
+    if p.returncode != 0:
         raise PassBackendError(err)
 
     return pass_output.decode()


### PR DESCRIPTION
There are cases when pass works just fine, but prints to stderr.

One of those cases is expiration of the key used to encrypt the keyring:

> gpg: Note: secret key ... expired at Sun 07 Nov 2021 02:19:20 PM CET

In these cases, the original code raises a `PassBackendError` which
doesn't seem appropriate as pass actually works just fine.

So instead of using the existance of output on stderr to determine
existance of an error condition, let's use pass' exit-code to
verify correct operation, as it only exits with 0, if it ran
successfully.