### PR TITLE
Support copying to clipboard on Wayland

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,7 @@ There are also some platform-specific requirements for copying code into the
 clipboard:
 
 * `xclip <http://sourceforge.net/projects/xclip>`_ for Xorg (Linux/BSD).
+* `wl-clipboard <https://github.com/bugaevc/wl-clipboard>`_ for Wayland (Linux/BSD).
 
 Installation
 ------------

--- a/totp/__init__.py
+++ b/totp/__init__.py
@@ -114,11 +114,17 @@ def copy_to_clipboard(text):
         elif platform.system() == "Windows":
             command = ["clip"]
         else:
-            selection = os.environ.get(
+            clipboard_type = os.environ.get(
                 "PASSWORD_STORE_X_SELECTION",
                 "clipboard",
             )
-            command = ["xclip", "-selection", selection]
+            session_type = os.environ.get("XDG_SESSION_TYPE")
+            if session_type == "wayland":
+                command = ["wl-copy"]
+                if clipboard_type == "primary":
+                    command.append("--primary")
+            else:
+                command = ["xclip", "-selection", clipboard_type]
 
         p = subprocess.Popen(
             command,

--- a/totp/__init__.py
+++ b/totp/__init__.py
@@ -118,8 +118,7 @@ def copy_to_clipboard(text):
                 "PASSWORD_STORE_X_SELECTION",
                 "clipboard",
             )
-            session_type = os.environ.get("XDG_SESSION_TYPE")
-            if session_type == "wayland":
+            if "WAYLAND_DISPLAY" in os.environ:
                 command = ["wl-copy"]
                 if clipboard_type == "primary":
                     command.append("--primary")


### PR DESCRIPTION
Implement automatic copying of TOTP codes to clipboard on Wayland sessions.

Detection of Wayland vs X11 is done by checking the presence of the `WAYLAND_DISPLAY` environment variable.

The copy is performed using the `wl-copy` command from the `wl-clipboard` package, which is the same dependency that `pass` uses.

The clipboard type (`primary`/`clipboard`) is tweakable like for X11, with the same environment variable, and defaults to `clipboard` like for X11.